### PR TITLE
fix: casing of http methods in APIs

### DIFF
--- a/client/src/routes/api/expense/[userId].ts
+++ b/client/src/routes/api/expense/[userId].ts
@@ -2,7 +2,7 @@ import { mockGetExpenses } from '$mock/api/expense/expenses';
 import type { GetExpensesResponse, GetExpensesRequestData } from '$shared/api/getExpenses';
 import type { RequestEvent } from '@sveltejs/kit';
 
-export async function get({
+export async function GET({
 	params,
 }: RequestEvent): Promise<{ status: number; body: GetExpensesResponse }> {
 	const res = mockGetExpenses({ userId: parseInt(params.userId) });

--- a/client/src/routes/api/expense/index.ts
+++ b/client/src/routes/api/expense/index.ts
@@ -4,7 +4,7 @@ import type { NewExpenseResponse, NewExpense } from '$shared/api/newExpense';
 import type { RequestEvent } from '@sveltejs/kit';
 
 /** @type {import('./[id]').RequestHandler} */
-export async function post({ request }: RequestEvent): Promise<NewExpenseResponse> {
+export async function POST({ request }: RequestEvent): Promise<NewExpenseResponse> {
 	const body: NewExpense = await request.json();
 	return mockNewExpense({ newExpense: body });
 }

--- a/client/src/routes/api/login.ts
+++ b/client/src/routes/api/login.ts
@@ -2,7 +2,7 @@ import { mockLogin } from '$mock/api/user/login';
 import type { LoginResponse, LoginRequestData } from '$shared/api/login';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
-export async function post({ request }: { request: Request }): Promise<LoginResponse> {
+export async function POST({ request }: { request: Request }): Promise<LoginResponse> {
 	const body: LoginRequestData = await request.json();
 
 	return mockLogin(body);

--- a/client/src/routes/api/logout.ts
+++ b/client/src/routes/api/logout.ts
@@ -2,6 +2,6 @@ import { mockLogout } from '$mock/api/user/logout';
 import type { LogoutRequest, LogoutResponse } from '$shared/api/logout';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
-export async function post({ request }: { request: LogoutRequest }): Promise<LogoutResponse> {
+export async function POST({ request }: { request: LogoutRequest }): Promise<LogoutResponse> {
 	return mockLogout(request);
 }

--- a/client/src/routes/api/me.ts
+++ b/client/src/routes/api/me.ts
@@ -2,7 +2,7 @@ import { mockWhoAmI } from '$mock/api/user/me';
 import type { MeResponse, MeRequestData } from '$shared/api/me';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
-export async function get({ request }: { request: Request }): Promise<MeResponse> {
+export async function GET({ request }: { request: Request }): Promise<MeResponse> {
 	const body: MeRequestData = await request.json();
 	return mockWhoAmI(body);
 }

--- a/client/src/routes/api/register.ts
+++ b/client/src/routes/api/register.ts
@@ -2,7 +2,7 @@ import { mockRegister } from '$mock/api/user/register';
 import type { RegisterResponse, RegisterRequestData } from '$shared/api/register';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
-export async function post({ request }: { request: Request }): Promise<RegisterResponse> {
+export async function POST({ request }: { request: Request }): Promise<RegisterResponse> {
 	const body: RegisterRequestData = await request.json();
 
 	return mockRegister(body);

--- a/client/src/routes/api/transaction/[id]/delete.ts
+++ b/client/src/routes/api/transaction/[id]/delete.ts
@@ -3,6 +3,6 @@ import { mockDeleteTransaction } from '$mock/api/expense/expenses';
 import type { DeleteTransactionResponse } from '$shared/api/deleteTransaction';
 
 /** @type {import('./[id]').RequestHandler} */
-export async function post({ params }: RequestEvent): Promise<DeleteTransactionResponse> {
+export async function POST({ params }: RequestEvent): Promise<DeleteTransactionResponse> {
 	return mockDeleteTransaction({ transactionId: parseInt(params.id) });
 }

--- a/client/src/routes/api/transaction/index.ts
+++ b/client/src/routes/api/transaction/index.ts
@@ -3,7 +3,7 @@ import type { NewTransactionResponse, NewTransaction } from '$shared/api/newTran
 import type { RequestEvent } from '@sveltejs/kit';
 
 /** @type {import('./[id]').RequestHandler} */
-export async function post({ request }: RequestEvent): Promise<NewTransactionResponse> {
+export async function POST({ request }: RequestEvent): Promise<NewTransactionResponse> {
 	const body: NewTransaction = await request.json();
 	return mockNewTransaction({ newTransaction: body });
 }


### PR DESCRIPTION
## Description of changes

### Fixes

```
Endpoint method "post" has changed to "POST". See https://github.com/sveltejs/kit/discussions/5359 for more information.
Error: Endpoint method "post" has changed to "POST". See https://github.com/sveltejs/kit/discussions/5359 for more information.
```