### PR TITLE
Hotfix: Lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["**"]
-    types: [review_requested, ready_for_review]
+    types: [opened, synchronize]
     paths:
       - "server/**"
   workflow_dispatch:

--- a/.github/workflows/svelte.yml
+++ b/.github/workflows/svelte.yml
@@ -5,7 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["**"]
-    types: [review_requested, ready_for_review]
+    types: [opened, synchronize]
     paths:
       - "client/**"
   workflow_dispatch:

--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -3,7 +3,6 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"endOfLine": "crlf",
 	"plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
 	"pluginSearchDirs": false,
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]

--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -3,6 +3,7 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
+	"endOfLine": "crlf",
 	"plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
 	"pluginSearchDirs": false,
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]

--- a/client/.vscode/extensions.json
+++ b/client/.vscode/extensions.json
@@ -1,9 +1,9 @@
 {
-    "recommendations": [
-        "svelte.svelte-vscode",
-        "bradlc.vscode-tailwindcss",
-        "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode",
-        "zixuanchen.vitest-explorer"
-    ]
+	"recommendations": [
+		"svelte.svelte-vscode",
+		"bradlc.vscode-tailwindcss",
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode",
+		"zixuanchen.vitest-explorer"
+	]
 }


### PR DESCRIPTION
- Fix failing build
- _Setting EOL in Prettier to CRLF to match other files in the project_
  - Reverted. It is still a mess Prettier cries on my local machine as Git checks out files as CRLF. But on Github these are LF files.
- Updated workflows for both client and server to run on:
  - opened: When you initially open the PR.
  - synchronize: When you push something.
  - Now PR checks will run on every commit, even when the PR is draft.